### PR TITLE
add ssh support

### DIFF
--- a/Dockerfile.tip
+++ b/Dockerfile.tip
@@ -1,5 +1,7 @@
 FROM golang:alpine
 RUN apk add --no-cache git curl
+RUN apk update && apk add openssh
+RUN mkdir /root/.ssh && echo "StrictHostKeyChecking no " > /root/.ssh/config
 
 WORKDIR "/go"
 


### PR DESCRIPTION
To use private repo's through Glide, we need SSH support in the docker container.

In addition to this, when using the container you will need to mount your SSH keys, through docker-compose you can add the following volume

- ~/.ssh/id_rsa:/root/.ssh/id_rsa